### PR TITLE
修复在windows系统下 上传文件到七牛时文件名为文件本身的路径的bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var through = require('through2');
 var qiniu = require('qiniu');
+var p = require('path');
 
 // consts
 const PLUGIN_NAME = 'gulp-qiniu-cdn';
@@ -42,9 +43,8 @@ function gulpQiniuCdn(conf) {
 
   // creating a stream through which each file will pass
   var stream = through.obj(function(file, enc, cb) {
-    var path = file.history[0];
-    var fileName = path.split("/").pop();
-
+    var path = file.path;
+    var fileName = p.basename(path);
     var extra = new qiniu.io.PutExtra(params, mimeType, crc32, checkCrc);
     qiniu.io.putFile(uptokenStr, fileName, path, extra, function(err, ret){
       if(!err) {


### PR DESCRIPTION
看了一下代码，发现是

``` javascript
    var path = file.history[0];
    var fileName = path.split("/").pop();
```

这两行的问题，在 windows 下路径的分隔是 `\\` ，而不是像 Linux/OS X 那样的 `/` ，因此 `path.split('/').pop()` 没办法拿到正确的文件名。使用Node自带的`path`库即可完美解决这个问题。
